### PR TITLE
Allow to exclude users from reports

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -149,6 +149,10 @@ module.exports = class Reporter {
   }
 
   scheduleReport(user, time) {
+    if (user.enabled === false) {
+      return;
+    }
+
     const date = moment(time, 'HH:mm')
       .utcOffset(user.timezone, true)
       .utcOffset(moment().utcOffset());


### PR DESCRIPTION
We warn for every user who has a non-empty report but no email address. With the new issues feature, however, all users receive emails now. This is especially annoying for:

 - People who are signed up but usually do not write code
 - Bots, who cannot have an email address

Yet, we do not want people to opt out of the notifications unnoticed.