### PR TITLE
Ignore "issues you could label and assign" from non-watcher repos

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const moment = require('moment');
 const schedule = require('node-schedule');
 const Report = require('./report');
-const { rateLimit } = require('./utils');
+const { filterAsync, rateLimit } = require('./utils');
 
 /**
  * Installation target type: User
@@ -26,6 +26,16 @@ const EVENT_REPORT = 'report';
  */
 const SEARCH_RATE = 25;
 
+/**
+ * Cache duration for issues in minutes
+ */
+const CACHE_ISSUES = 10;
+
+/**
+ * Cache duration for watchers in minutes
+ */
+const CACHE_WATCHERS = 1440; // 1 day
+
 module.exports = class Reporter {
   constructor(robot, installation, config) {
     this.robot = robot;
@@ -36,6 +46,7 @@ module.exports = class Reporter {
     this.emitter = new EventEmitter();
     this.users = {};
     this.jobs = {};
+    this.watchers = {};
 
     this.searchIssuesRateLimited = rateLimit(this.searchIssues, 1000 * (60 / SEARCH_RATE));
     this.setupUsers();
@@ -107,6 +118,49 @@ module.exports = class Reporter {
     );
   }
 
+  async getNewIssues(github) {
+    if (this.newIssues) {
+      return this.newIssues;
+    }
+
+    // Look for all public issues that haven't been assigned or labeled yet
+    // We should also filter out issues with comments from organization members
+    const date = moment().subtract(this.config.get().newIssueDays, 'days').format('YYYY-MM-DD');
+    this.newIssues = this.searchIssuesRateLimited(github,
+      `is:open is:issue is:public no:assignee no:label created:>=${date}`);
+
+    // Automatically clear the issues cache when the timeout expires
+    setTimeout(() => { this.newIssues = null; }, CACHE_ISSUES * 60 * 1000);
+    return this.newIssues;
+  }
+
+  async getWatchers(github, repo) {
+    if (this.watchers[repo]) {
+      return this.watchers[repo];
+    }
+
+    const owner = this.installation.account.login;
+    this.logger.debug(`Loading watchers for ${owner}/${repo}`);
+    const request = github.activity.getWatchersForRepo({ owner, repo, per_page: 100 });
+    this.watchers[repo] = github.paginate(request, response =>
+      response.data.map(user => user.login));
+
+    // Automatically clear the watcher cache when the timeout expires
+    setTimeout(() => { delete this.watchers[repo]; }, CACHE_WATCHERS * 60 * 1000);
+    return this.watchers[repo];
+  }
+
+  async isInWatchedRepo(github, issue, user) {
+    // Since the issue doesn't include repository information, we need to parse it
+    const repo = /[^/]+$/.exec(issue.repository_url);
+    if (repo == null) {
+      return false;
+    }
+
+    const watchers = await this.getWatchers(github, repo[0]);
+    return watchers.includes(user.login);
+  }
+
   async getReportForUser(user) {
     const github = await this.getGithub();
     const login = user.login.toLowerCase();
@@ -123,11 +177,9 @@ module.exports = class Reporter {
     const toComplete = await this.searchIssuesRateLimited(github,
       `is:open is:pr -review:none assignee:${login}`);
 
-    // Look for all public issues that haven't been assigned or labeled yet
-    // We should also filter out issues with comments from organization members
-    const date = moment().subtract(this.config.get().newIssueDays, 'days').format('YYYY-MM-DD');
-    const newIssues = await this.searchIssuesRateLimited(github,
-      `is:open is:issue is:public no:assignee no:label created:>=${date}`);
+    // Look for all public issues that haven't been handled yet
+    const newIssues = await filterAsync(await this.getNewIssues(github), issue =>
+      this.isInWatchedRepo(github, issue, user));
 
     // We can pull this out of here when we have issue or stuff we query
     // for now leave it here

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,8 +52,22 @@ function rateLimit(callback, delay) {
   };
 }
 
+/**
+ * Asynchronously calls the predicate on every element of the array and filters
+ * for all elements where the predicate resolves to true.
+ *
+ * @param {Array} array An array to filter
+ * @param {Function} predicate A predicate function that resolves to a boolean
+ * @param {any} args Any further args passed to the predicate
+ */
+async function filterAsync(array, predicate, ...args) {
+  const verdicts = await Promise.all(array.map(predicate, ...args));
+  return array.filter((element, index) => verdicts[index]);
+}
+
 module.exports = {
   isDryRun,
   shouldPerform,
   rateLimit,
+  filterAsync,
 };


### PR DESCRIPTION
So this doesn't happen (I don't track any of those repos, yet get notifications about them):

![screen shot 2017-10-02 at 10 13 37](https://user-images.githubusercontent.com/1523305/31068905-60026c96-a75a-11e7-8902-be9287e4f865.png)
