### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ git:
   depth: 1
 
 node_js:
+  - "node"
+  - "10"
   - "8"
-  - "9"


### PR DESCRIPTION
Test against Node.js 8, 10 and 11 (current stable). Node.js 9 has already reached its EOL (like all previous odd release branches).